### PR TITLE
Golang client for redis pub/sub chat-room demo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+#config file
+*.ini

--- a/chat_msg_sample.json
+++ b/chat_msg_sample.json
@@ -1,0 +1,5 @@
+{
+    "user":"localhost:1234",
+    "time":12345678,
+    "msg":"hello world"
+}

--- a/chat_msg_sample.json
+++ b/chat_msg_sample.json
@@ -1,5 +1,6 @@
 {
-    "user":"localhost:1234",
-    "time":12345678,
-    "msg":"hello world"
+    "user":"localhost:1234",   //user identifier
+    "time":12345678,           //msg create time, unix timestamp
+    "msg":"hello world",       //msg content
+    "type":1                   //msg type, 0 for broadcast, 1 for chat content
 }

--- a/clichat.go
+++ b/clichat.go
@@ -1,0 +1,114 @@
+package chat
+
+import (
+	"bufio"
+	"fmt"
+	"github.com/Unknwon/goconfig"
+	"os"
+	"redis"
+	"strconv"
+	"time"
+)
+
+type redisConfig struct {
+	host string
+	port int
+}
+
+type chatMsg struct {
+	user string
+	time time.Time
+	msg  []byte
+}
+
+var channel = "chat_channel"
+var user string
+
+func main() {
+	client, subClient := Init()
+	welcome()
+	inputReader := bufio.NewReader(os.Stdin)
+	for {
+		input, err := inputReader.ReadString('\n')
+		if err != nil {
+			panic(err)
+		}
+
+		if input == "\n" {
+			os.Exit(0)
+		}
+
+		rcvCnt, err := client.Publish(channel, []byte(input))
+		if err != nil {
+			fmt.Printf("Error on Publish - %s", err)
+		} else {
+			fmt.Printf("Message sent to %d subscribers\n", rcvCnt)
+		}
+	}
+	fmt.Println(subClient)
+}
+
+func welcome() {
+	fmt.Println("======================================")
+	fmt.Println("=                                    =")
+	fmt.Println("=      welcome to the chat room      =")
+	fmt.Println("=                                    =")
+	fmt.Println("======================================")
+}
+
+func Init() (redis.AsyncClient, redis.PubSubClient) {
+	hostname, err := os.Hostname()
+	if err != nil {
+		fmt.Println("failed get hostname")
+	}
+	user = fmt.Sprintf("%s:%d", hostname, os.Getpid())
+
+	cfg, err := getConfig()
+	if err != nil {
+		panic(err)
+	}
+
+	spec := redis.DefaultSpec().Host(cfg.host).Port(cfg.port)
+
+	client, err := redis.NewAsynchClientWithSpec(spec)
+	if err != nil {
+		panic(err)
+	}
+
+	subClient, err := redis.NewPubSubClientWithSpec(spec)
+	if err != nil {
+		panic(err)
+	}
+
+	subClient.Subscribe(channel)
+	client.Publish(channel, []byte("hi, i am online."))
+	return client, subClient
+}
+
+func getConfig() (*redisConfig, error) {
+	config, err := goconfig.LoadConfigFile("chat_conf.ini")
+	if err != nil {
+		return nil, err
+	}
+
+	host, err := config.GetValue("redis", "host")
+	if err != nil {
+		return nil, err
+	}
+
+	portNum, err := config.GetValue("redis", "port")
+	if err != nil {
+		return nil, err
+	}
+
+	port, err := strconv.Atoi(portNum)
+	if err != nil {
+		return nil, err
+	}
+
+	// cfg := new(redisConfig)
+	// cfg.host = host
+	// cfg.port = port
+	cfg := &redisConfig{host: host, port: port}
+	return cfg, nil
+}

--- a/clichat_test.go
+++ b/clichat_test.go
@@ -1,6 +1,7 @@
 package chat
 
 import (
+	"encoding/json"
 	"fmt"
 	"github.com/Unknwon/goconfig"
 	"os"
@@ -90,19 +91,18 @@ func TestUsername(t *testing.T) {
 
 func TestEncode(t *testing.T) {
 	var oriMsg chatMsg
-	oriMsg.user = "localhost:1234"
-	oriMsg.time = time.Now().Unix()
-	oriMsg.msg = "hello world"
-	fmt.Println("msg:", oriMsg)
+	oriMsg.User = "localhost:1234"
+	oriMsg.Time = time.Now().Unix()
+	oriMsg.Msg = "hello world"
+	fmt.Println("before encode:", oriMsg)
 
-	err := enc.Encode(oriMsg)
+	msg, err := oriMsg.jsonEncode()
 	if err != nil {
 		t.Error(err)
 	}
+	fmt.Println("after encode", msg)
+
 	cmsg := new(chatMsg)
-	err = dec.Decode(&cmsg)
-	if err != nil {
-		t.Error(err)
-	}
-	fmt.Println("msg:", cmsg)
+	json.Unmarshal([]byte(msg), cmsg)
+	fmt.Println("after decode:", cmsg)
 }

--- a/clichat_test.go
+++ b/clichat_test.go
@@ -1,0 +1,85 @@
+package chat
+
+import (
+	"fmt"
+	"github.com/Unknwon/goconfig"
+	"os"
+	"redis"
+	"strconv"
+	"testing"
+)
+
+func TestRedisConn(t *testing.T) {
+	testKey := "test_go_redis"
+	testVal := "hello"
+	client, err := redis.NewSynchClient()
+	if err != nil {
+		t.Error(err)
+	}
+
+	client.Set(testKey, []byte(testVal))
+	value, err := client.Get(testKey)
+	if err != nil {
+		t.Error(err)
+	}
+
+	fmt.Println(testVal, "====", string(value))
+	if testVal != string(value) {
+		t.Error("value getting from redis is not equal to origin")
+	}
+}
+
+func TestInit(t *testing.T) {
+	channel := "chat_channel"
+	spec := redis.DefaultSpec().Host("127.0.0.1").Port(6379)
+	client, err := redis.NewAsynchClientWithSpec(spec)
+	if err != nil {
+		t.Error(err)
+	}
+
+	subClient, err := redis.NewPubSubClientWithSpec(spec)
+	if err != nil {
+		t.Error(err)
+	}
+
+	subClient.Subscribe(channel)
+	client.Publish(channel, []byte("hi, i am online."))
+	fmt.Println("client init done")
+}
+
+func TestConfig(t *testing.T) {
+	config, err := goconfig.LoadConfigFile("chat_conf.ini")
+	if err != nil {
+		t.Error(err)
+	}
+
+	host, err := config.GetValue("redis", "host")
+	if err != nil {
+		t.Error(err)
+	}
+
+	port, err := config.GetValue("redis", "port")
+	if err != nil {
+		t.Error(err)
+	}
+
+	fmt.Println("redis config, host:", host, " port:", port)
+
+	portNum, err := strconv.Atoi(port)
+	if err != nil {
+		t.Error(err)
+	}
+
+	cfg := &redisConfig{host: host, port: portNum}
+	fmt.Println("create config obj:", cfg)
+	fmt.Println("redis config, host:", cfg.host, " port:", cfg.port)
+}
+
+func TestUsername(t *testing.T) {
+	hostname, err := os.Hostname()
+	if err != nil {
+		fmt.Println("failed get hostname")
+	}
+	user = fmt.Sprintf("%s:%d", hostname, os.Getpid())
+	fmt.Println("user:", user)
+}

--- a/clichat_test.go
+++ b/clichat_test.go
@@ -1,4 +1,4 @@
-package chat
+package main
 
 import (
 	"encoding/json"
@@ -79,6 +79,7 @@ func TestEncode(t *testing.T) {
 	oriMsg.User = "localhost:1234"
 	oriMsg.Time = time.Now().Unix()
 	oriMsg.Msg = "hello world"
+	oriMsg.Type = MsgTypeContent
 	fmt.Println("before encode:", oriMsg)
 
 	msg, err := oriMsg.jsonEncode()
@@ -101,7 +102,7 @@ func TestPubSub(t *testing.T) {
 	fmt.Println("client start")
 	// defer client.Close()
 
-	pubMsg := &chatMsg{"localhost:1234", time.Now().Unix(), "hello, i am online !"}
+	pubMsg := &chatMsg{"localhost:1234", time.Now().Unix(), "hello, i am online !", MsgTypeContent}
 	jsonMessage, err := pubMsg.jsonEncode()
 	if err != nil {
 		t.Error(err)
@@ -153,8 +154,9 @@ func TestPubSub(t *testing.T) {
 			fmt.Println("recv msg:", subMsg)
 
 			json.Unmarshal([]byte(subMsg.Payload), recvMsg)
-			fmt.Println(recvMsg.User, " ", time.Unix(recvMsg.Time, 0).Format(time.ANSIC), " :")
-			fmt.Println(recvMsg.Msg)
+			// fmt.Println(recvMsg.User, " ", time.Unix(recvMsg.Time, 0).Format(time.ANSIC), " :")
+			// fmt.Println(recvMsg.Msg)
+			printMsg(recvMsg)
 		}
 	}(pubsub)
 

--- a/clichat_test.go
+++ b/clichat_test.go
@@ -7,6 +7,7 @@ import (
 	"redis"
 	"strconv"
 	"testing"
+	"time"
 )
 
 func TestRedisConn(t *testing.T) {
@@ -27,6 +28,7 @@ func TestRedisConn(t *testing.T) {
 	if testVal != string(value) {
 		t.Error("value getting from redis is not equal to origin")
 	}
+	defer client.Quit()
 }
 
 func TestInit(t *testing.T) {
@@ -45,6 +47,8 @@ func TestInit(t *testing.T) {
 	subClient.Subscribe(channel)
 	client.Publish(channel, []byte("hi, i am online."))
 	fmt.Println("client init done")
+	defer client.Quit()
+	defer subClient.Quit()
 }
 
 func TestConfig(t *testing.T) {
@@ -82,4 +86,23 @@ func TestUsername(t *testing.T) {
 	}
 	user = fmt.Sprintf("%s:%d", hostname, os.Getpid())
 	fmt.Println("user:", user)
+}
+
+func TestEncode(t *testing.T) {
+	var oriMsg chatMsg
+	oriMsg.user = "localhost:1234"
+	oriMsg.time = time.Now().Unix()
+	oriMsg.msg = "hello world"
+	fmt.Println("msg:", oriMsg)
+
+	err := enc.Encode(oriMsg)
+	if err != nil {
+		t.Error(err)
+	}
+	cmsg := new(chatMsg)
+	err = dec.Decode(&cmsg)
+	if err != nil {
+		t.Error(err)
+	}
+	fmt.Println("msg:", cmsg)
 }


### PR DESCRIPTION
Use JSON as the message encoding format, because it's cross platform capabilities.
Of course, using protocol buffer  or msgpack will be more secure. But let's start with a simple solution.
